### PR TITLE
change feedback link to discord server invite

### DIFF
--- a/theme.config.js
+++ b/theme.config.js
@@ -41,6 +41,7 @@ const themeConfig = {
   },
   feedback: {
     content: () => useLocalesMap(feedbackLinkMap),
+    useLink: () => "https://discord.gg/ntts", 
   },
   navigation: false,
   sidebar: {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [ ] Updating existing documentation
- [X] Other updates

On each page there is a "[Question? Give us feedback →](#)" link. (see screenshot)

This was referring to the Issues page of this repo. But since that feature is disabled here the user would land on a 404 error page. I thought of 2 solutions to this: a) remove it or b) change it to the discord invite link. I choose to let it redirect to the discord invite link. 

If any other solution to this is wanted, please let me know. 

<img width="800" alt="image" src="https://github.com/NoTextToSpeech/ntts-site/assets/18190639/13d4dc0b-8c77-4abe-9b49-cf5c4f569639">

Thanks for reading this 😄 


